### PR TITLE
removing unneeded clojuers

### DIFF
--- a/lib/acl.js
+++ b/lib/acl.js
@@ -17,16 +17,14 @@ Acl.prototype.addResource = function(resource, parent) {
 
 Acl.prototype.allow = function(role, resource, actions, assertion) {
   if (!Array.isArray(actions)) actions = [actions];
-  for (var i in actions) (function(action) {
-    this.permissions.push(new Permission(role || null, resource || null, action || null, assertion || true));
-  }).call(this, actions[i]);
+  for (var i in actions)
+    this.permissions.push(new Permission(role || null, resource || null, actions[i] || null, assertion || true));
 };
 
 Acl.prototype.deny = function(role, resource, actions, assertion) {
   if (!Array.isArray(actions)) actions = [actions];
-  for (var i in actions) (function(action) {
-    this.permissions.push(new Permission(role || null, resource || null, action || null, assertion || false));
-  }).call(this, actions[i]);
+  for (var i in actions)
+    this.permissions.push(new Permission(role || null, resource || null, actions[i] || null, assertion || false));
 };
 
 Acl.prototype.query = function(role, resource, action, done) {
@@ -39,15 +37,12 @@ Acl.prototype.query = function(role, resource, action, done) {
   roles = getParentRoles.call(this, role);
   resources = getParentResources.call(this, resource);
 
-  for (var i in roles) (function(_role){
-    for (var j in resources) (function(_resource){
-      for (var k = this.permissions.length - 1; k >= 0; k--) (function(test_role, test_resource, test_permission) {
-        if (test_permission.match(test_role || null, test_resource || null, action || null)) {
-          matches.push(test_permission);
+  for (var i in roles) 
+    for (var j in resources) 
+      for (var k = this.permissions.length - 1; k >= 0; k--) 
+        if (this.permissions[k].match(roles[i] || null, resources[j] || null, action || null)) {
+          matches.push(this.permissions[k]);
         }
-      })(_role, _resource, this.permissions[k]);
-    }).call(this, resources[j]);
-  }).call(this, roles[i]);
 
   var pl = new PermissionList(matches, role, resource, action, done);
   pl.next();


### PR DESCRIPTION
I noticed undeeded overhead in allow, deny and query - there is a clojure there for no good reason.
for example, in Acl.prototype.allow - you create a clojure and capture the value of actions[i] even though there is no async function in that loop.
I removed those clojures.
